### PR TITLE
fix "questionId is already in use" error

### DIFF
--- a/runtime-rpc/src/main/java/org/capnproto/RpcState.java
+++ b/runtime-rpc/src/main/java/org/capnproto/RpcState.java
@@ -758,10 +758,12 @@ final class RpcState<VatId> {
         if (ctx != null) {
             ctx.requestCancel();
         }
-        else {
-            var questionId = finish.getQuestionId();
-            answers.erase(questionId);
-        }
+
+        // Remove question id
+        // this is a different then c++ implementation, but it is required as java's promises doesn't support
+        // all features of kj's promises
+        var questionId = finish.getQuestionId();
+        answers.erase(questionId);
 
         if (exportsToRelease != null) {
             this.releaseExports(exportsToRelease);


### PR DESCRIPTION
Hi Vaci, I'm currently using your library in a project.

I found an issue in rpc communication.

Imagine this flow between a client (java) and a server (C++):

```
Server->Client: Call(QuestionId=8)
  the client insert 8 in answers table

Server->Client: Finish(QuestionId=8)
  the client cancels the future without erasing the id "8" from the answer table

Server->Client: Call(QuestionId=8)
  the client try to re-insert 8 in answers table but it is still active causing error (and disconnection if assertions are enabled)
```

In C++ this is not an issue as the flow always guarantees that `answers.erase` is always called after [`context->requestCancel();`](https://github.com/capnproto/capnproto/blob/b49431c48d40490ef979247d308af63345376cee/c++/src/capnp/rpc.c++#L2914)

The flow in c++ is really complex, but I think this fix is more suitable for java (which has no destructor support or attachment in promises)
