### PR TITLE
Fix generic structs with non-generic interface as type parameter

### DIFF
--- a/compiler/src/main/cpp/capnpc-java.c++
+++ b/compiler/src/main/cpp/capnpc-java.c++
@@ -338,18 +338,22 @@ private:
       if (liteMode) {
         return kj::strTree("org.capnproto.Capability.", suffix);
       }
+      auto interfaceSuffix = kj::str(suffix);
+      if(suffix == kj::str("Builder") || suffix == kj::str("Reader")) {
+        interfaceSuffix = kj::str("Client");
+      }
       auto interfaceSchema = type.asInterface();
       if (interfaceSchema.getProto().getIsGeneric()) {
         auto typeArgs = getTypeArguments(interfaceSchema, interfaceSchema, kj::str(suffix));
         return kj::strTree(
-          javaFullName(interfaceSchema), ".", suffix, "<",
+          javaFullName(interfaceSchema), ".", interfaceSuffix, "<",
           kj::StringTree(KJ_MAP(arg, typeArgs){
               return kj::strTree(arg);
             }, ", "),
           ">"
           );
       } else {
-        return kj::strTree(javaFullName(type.asInterface()), ".", suffix);
+        return kj::strTree(javaFullName(type.asInterface()), ".", interfaceSuffix);
       }
     }
     case schema::Type::LIST:

--- a/runtime/src/main/java/org/capnproto/Capability.java
+++ b/runtime/src/main/java/org/capnproto/Capability.java
@@ -11,8 +11,7 @@ import static org.capnproto.ClientHook.NULL_CAPABILITY_BRAND;
 public final class Capability {
 
     public static abstract class Factory<T extends ClientBase>
-            implements FromPointerReader<T>,
-                       FromPointerBuilder<T>,
+            implements PointerFactory<T, T>,
                        SetPointerBuilder<T, T> {
 
         public abstract T newClient(ClientHook hook);


### PR DESCRIPTION
Currently,  the autogenerated code doesn't compile when using generic interfaces or generic structs with interfaces as type parameters. We fixed it for the struct case, but more work is necessary for generic interfaces.

This should work with this commit:
```capnp
struct Res(T, E) {
    union {
        ok @0 :T;
        error @1 :E;
    }
}

struct Ok {}

interface SomeInterface {
        someMethod @0 ();
}

interface BootstrapInterface {
    bootstrapMethod @0 () -> (result :Res(SomeInterface, Ok));
}
```